### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,12 @@
+This is related to issue # *replace or delete if N/A*
+
 ## Description / Changes Made
-This is related to issue ###
 - *List the specific changes made in this pull request. Include any new features, bug fixes, improvements, or refactorings.*
 - 
+ 
 
-### Screenshots (optional)
+
+## Screenshots (optional)
 ![image](#)
 
 ## How to Test

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Description / Changes Made
+This is related to issue ###
+- *List the specific changes made in this pull request. Include any new features, bug fixes, improvements, or refactorings.*
+- 
+
+### Screenshots (optional)
+![image](#)
+
+## How to Test
+1. *Provide step-by-step instructions on how to test the changes in this pull request for the reviewers. Include any specific setups or configurations needed.*
+2. 
+
+## Checklist
+- [ ] I have added/updated relevant documentation, and I have followed the coding style guidelines.
+- [ ] I have added/updated tests, and I have run the test suite and all tests pass.
+- [ ] I have checked for any potential conflicts with other branches and fixed any merge conflicts.


### PR DESCRIPTION
## Description / Changes Made
- Added PR template to streamline PR process

## How to Test
1. PR template only shows up on PR's on Github after merged into main/master branch, so we will have to test it after the merge, unless we want to add branch specific PR templates.

## Checklist
- [x] I have added/updated relevant documentation, and I have followed the coding style guidelines.
- [x] I have added/updated tests, and I have run the test suite and all tests pass.
- [x] I have checked for any potential conflicts with other branches and fixed any merge conflicts.
