### PR TITLE
Fixes Issue #9, accepting Pull Requests from branches not named main

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,7 +4,8 @@ on:
     branches: 
       - "*"
   pull_request:
-    branches: [main]
+    branches:
+      - "*"
 
 jobs:
   build:
@@ -15,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0 
 
       - name: Prettify frontend code

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,10 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          fetch-depth: 0 
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Prettify frontend code
         uses: creyD/prettier_action@v4.3

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,8 +16,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0 
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Prettify frontend code
         uses: creyD/prettier_action@v4.3


### PR DESCRIPTION
Fixes Issue #9 

## Description / Changes Made

- _Modified GitHub workflow file to:_
    - Run action on a pull request to any branch, not just the main branch.
    - Accept pul requests from any branch name, not just main. 

## How to Test

1. _Push to the main branch from a fork with a branch that is not named "main"_

## Checklist

- [x] Verify that GitHub action passes when being pushed from a branch not named main
