### PR TITLE
Refactor Create Page Tabs

### DIFF
--- a/frontend/app/(tabs)/create.tsx
+++ b/frontend/app/(tabs)/create.tsx
@@ -16,7 +16,7 @@ import {
   TextArea,
   Switch
 } from 'tamagui';
-import type { TabsContentProps } from 'tamagui';
+
 
 export default function Create() {
   const [isEnabled, setEnabledElements] = useState(false);
@@ -24,9 +24,9 @@ export default function Create() {
   return (
     <View>
       <YStack>
-        <H4 style={{ alignSelf: 'center' }}>NEW POST</H4>
+        <H4 style={{ alignSelf: 'center', color: 'black' }}>NEW POST</H4>
         <XStack>
-          <Text fontSize="$5" paddingStart="$5">is this a recipe?</Text>
+          <Text color={'black'} fontSize="$5" paddingStart="$5">is this a recipe?</Text>
           <Switch marginLeft="$2" size="$3" onCheckedChange={() => setEnabledElements(!isEnabled)}>
             <Switch.Thumb animation="bouncy" />
           </Switch>

--- a/frontend/app/(tabs)/create.tsx
+++ b/frontend/app/(tabs)/create.tsx
@@ -1,5 +1,5 @@
 import { View } from '@/components/Themed';
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Button,
   H1,

--- a/frontend/app/(tabs)/create.tsx
+++ b/frontend/app/(tabs)/create.tsx
@@ -14,9 +14,8 @@ import {
   H5,
   Text,
   TextArea,
-  Switch
+  Switch,
 } from 'tamagui';
-
 
 export default function Create() {
   const [isEnabled, setEnabledElements] = useState(false);
@@ -26,71 +25,75 @@ export default function Create() {
       <YStack>
         <H4 style={{ alignSelf: 'center', color: 'black' }}>NEW POST</H4>
         <XStack>
-          <Text color={'black'} fontSize="$5" paddingStart="$5">is this a recipe?</Text>
-          <Switch marginLeft="$2" size="$3" onCheckedChange={() => setEnabledElements(!isEnabled)}>
-            <Switch.Thumb animation="bouncy" />
+          <Text color={'black'} fontSize='$5' paddingStart='$5'>
+            is this a recipe?
+          </Text>
+          <Switch
+            marginLeft='$2'
+            size='$3'
+            onCheckedChange={() => setEnabledElements(!isEnabled)}
+          >
+            <Switch.Thumb animation='bouncy' />
           </Switch>
         </XStack>
-        {
-          !isEnabled ? (
-            <YStack>          
-              <TextArea
-                placeholder={'Description...'}
-                multiline={true}
-                style={{
-                  height: 130,
-                  borderRadius: 5,
-                  paddingHorizontal: 10,
-                  textAlignVertical: 'top',
-                }}
-              />
-              <TextArea
-                placeholder={'List Steps...'}
-                multiline={true}
-                style={{
-                  height: 130,
-                  borderRadius: 5,
-                  paddingHorizontal: 10,
-                  textAlignVertical: 'top',
-                }}
-              />
-              <TextArea
-                placeholder={'List Ingredients...'}
-                multiline={true}
-                style={{
-                  height: 130,
-                  borderRadius: 5,
-                  paddingHorizontal: 10,
-                  textAlignVertical: 'top',
-                }}
-              />
-            </YStack>
-          ) : null
-        }
-        {
-          isEnabled ? (
-            <YStack>
-              <TextArea
-                placeholder={'Upload IMG...'}
-                multiline={true}
-                style={{
-                  height: 130,
-                  borderRadius: 5,
-                  paddingHorizontal: 10,
-                  textAlignVertical: 'top',
-                }} />
-              <TextArea
-                placeholder={'Caption...'}
-                multiline={true}
-                style={{
-                  height: 130,
-                  borderRadius: 5,
-                  paddingHorizontal: 10,
-                  textAlignVertical: 'top',
-                }}
-              />
-            </YStack>) : null
-        }
+        {!isEnabled ? (
+          <YStack>
+            <TextArea
+              placeholder={'Description...'}
+              multiline={true}
+              style={{
+                height: 130,
+                borderRadius: 5,
+                paddingHorizontal: 10,
+                textAlignVertical: 'top',
+              }}
+            />
+            <TextArea
+              placeholder={'List Steps...'}
+              multiline={true}
+              style={{
+                height: 130,
+                borderRadius: 5,
+                paddingHorizontal: 10,
+                textAlignVertical: 'top',
+              }}
+            />
+            <TextArea
+              placeholder={'List Ingredients...'}
+              multiline={true}
+              style={{
+                height: 130,
+                borderRadius: 5,
+                paddingHorizontal: 10,
+                textAlignVertical: 'top',
+              }}
+            />
+          </YStack>
+        ) : null}
+        {isEnabled ? (
+          <YStack>
+            <TextArea
+              placeholder={'Upload IMG...'}
+              multiline={true}
+              style={{
+                height: 130,
+                borderRadius: 5,
+                paddingHorizontal: 10,
+                textAlignVertical: 'top',
+              }}
+            />
+            <TextArea
+              placeholder={'Caption...'}
+              multiline={true}
+              style={{
+                height: 130,
+                borderRadius: 5,
+                paddingHorizontal: 10,
+                textAlignVertical: 'top',
+              }}
+            />
+          </YStack>
+        ) : null}
         <Button backgroundColor={'cyan'} mx={'$4'}>
           <Text color={'$black2'}>Post</Text>
         </Button>

--- a/frontend/app/(tabs)/create.tsx
+++ b/frontend/app/(tabs)/create.tsx
@@ -1,27 +1,85 @@
 import { View } from '@/components/Themed';
-import React from 'react';
+import React, { useState } from 'react';
 import { TextInput } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Button, H1, H2, H4, YStack, Text } from 'tamagui';
+import { Button, H1, H2, H4, YStack, Text, Switch, XStack } from 'tamagui';
 
 // should open up gallery so people can upload vid/images
 // have option to just do text so new recipe
 
 export default function Create() {
+  const [isEnabled, setEnabledElements] = useState(false);
+
   return (
     <View>
       <YStack>
         <H4 style={{ alignSelf: 'center' }}>NEW POST</H4>
-        <TextInput
-          placeholder={'Hungry?'}
-          multiline={true}
-          style={{
-            height: 130,
-            borderRadius: 5,
-            paddingHorizontal: 10,
-            textAlignVertical: 'top',
-          }}
-        />
+        <XStack>
+          <Text fontSize="$5" paddingStart="$5">is this a recipe?</Text>
+          <Switch marginLeft="$2" size="$3" onCheckedChange={() => setEnabledElements(!isEnabled)}>
+            <Switch.Thumb animation="bouncy" />
+          </Switch>
+        </XStack>
+        {
+          !isEnabled ? (
+            <YStack>          
+              <TextInput
+                placeholder={'Description...'}
+                multiline={true}
+                style={{
+                  height: 130,
+                  borderRadius: 5,
+                  paddingHorizontal: 10,
+                  textAlignVertical: 'top',
+                }}
+              />
+              <TextInput
+                placeholder={'List Steps...'}
+                multiline={true}
+                style={{
+                  height: 130,
+                  borderRadius: 5,
+                  paddingHorizontal: 10,
+                  textAlignVertical: 'top',
+                }}
+              />
+              <TextInput
+                placeholder={'List Ingredients...'}
+                multiline={true}
+                style={{
+                  height: 130,
+                  borderRadius: 5,
+                  paddingHorizontal: 10,
+                  textAlignVertical: 'top',
+                }}
+              />
+            </YStack>
+          ) : null
+        }
+        {
+          isEnabled ? (
+            <YStack>
+              <TextInput
+                placeholder={'Upload IMG...'}
+                multiline={true}
+                style={{
+                  height: 130,
+                  borderRadius: 5,
+                  paddingHorizontal: 10,
+                  textAlignVertical: 'top',
+                }} />
+              <TextInput
+                placeholder={'Caption...'}
+                multiline={true}
+                style={{
+                  height: 130,
+                  borderRadius: 5,
+                  paddingHorizontal: 10,
+                  textAlignVertical: 'top',
+                }}
+              />
+            </YStack>) : null
+        }
         <Button backgroundColor={'cyan'} mx={'$4'}>
           <Text color={'$black2'}>Post</Text>
         </Button>


### PR DESCRIPTION
The tabs previously used will not be beneficial. They are still in beta and after using them to do not align with our needs.

## Description / Changes Made

- instead of tabs, used a switch control to check if it was a recipe or not
- when the switch is checked, it will show elements that are specific for a recipe post
  - not checked? page shows elements related to a regular BYTE post

## How to Test

1. Navigate to the Create tab
2. Ensure there is a switch
3. Check the switch so it is a Recipe Post
4. Ensure that the text areas `Description`, `List the Steps`, and `List the Ingredients` are there
5. Uncheck the switch
6. Ensure those elements are hidden and the elements for a Byte (regular post) show again

## Checklist

- [ ] I have added/updated relevant documentation, and I have followed the coding style guidelines.
- [ ] I have added/updated tests, and I have run the test suite and all tests pass.
- [ ] I have checked for any potential conflicts with other branches and fixed any merge conflicts.
