### PR TITLE
Background fix

### DIFF
--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -5,43 +5,48 @@
  */
 
 import { Link } from 'expo-router';
-import { TouchableHighlight, ImageBackground } from 'react-native';
-import { Button, YStack, Image, styled, Avatar, Text, View } from 'tamagui';
+import { TouchableHighlight, ImageBackground, Dimensions } from 'react-native';
+import { Button, YStack, Image, styled, Avatar, Text, View, ScrollView } from 'tamagui';
 
 export default function Index() {
   const backgroundImage = { uri: 'https://picsum.photos/1080/1920' };
-  const StyledBG = styled(ImageBackground, { flex: 1 });
+  const windowWidth = Dimensions.get('window').width
+  const windowHeight = Dimensions.get('window').height
   return (
-    <View flex={1}>
-      <StyledBG resizeMode='contain' source={backgroundImage}>
-        <Text>homepage</Text>
-        <YStack
-          backgroundColor={'grey'}
-          width={70}
-          height={240}
-          x={338}
-          y={300}
-          justifyContent={'space-around'}
-          alignItems={'center'}
-        >
-          <Avatar circular size='$6'>
-            <Avatar.Image src='https://picsum.photos/300/300' />
-          </Avatar>
-          <TouchableHighlight
-            onPress={() => console.log('Button pressed')}
-            underlayColor='crimson'
-            activeOpacity={1}
-          >
-            <Image source={require('../../assets/images/heart.png')} />
-          </TouchableHighlight>
-          <Button size='$5' circular>
-            comm
-          </Button>
-          <Button size='$5' circular>
-            share
-          </Button>
-        </YStack>
-      </StyledBG>
-    </View>
+      <ScrollView>
+          <View flexDirection={'row-reverse'} width={windowWidth} height={windowHeight}
+                verticalPadding={60}>
+            <Image source={backgroundImage}
+                 width={windowWidth} height={windowHeight-100}
+                 resizeImage={'contain'}
+                 position={'absolute'}
+            />
+            <YStack
+              backgroundColor={'grey'}
+              width={70}
+              height={240}
+              y={300}
+              justifyContent={'space-around'}
+              alignItems={'center'}
+            >
+              <Avatar circular size='$6'>
+                <Avatar.Image src='https://picsum.photos/300/300' />
+              </Avatar>
+              <TouchableHighlight
+                onPress={() => console.log('Button pressed')}
+                underlayColor='crimson'
+                activeOpacity={1}
+              >
+                <Image source={require('../../assets/images/heart.png')} />
+              </TouchableHighlight>
+              <Button size='$5' circular>
+                comm
+              </Button>
+              <Button size='$5' circular>
+                share
+              </Button>
+            </YStack>
+          </View>
+      </ScrollView>
   );
 }

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Link } from 'expo-router';
-import { TouchableHighlight, ImageBackground, Dimensions } from 'react-native';
+import { TouchableHighlight, Dimensions } from 'react-native';
 import { Button, YStack, Image, styled, Avatar, Text, View, ScrollView } from 'tamagui';
 
 export default function Index() {

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -6,7 +6,16 @@
 
 import { Link } from 'expo-router';
 import { TouchableHighlight, Dimensions } from 'react-native';
-import { Button, YStack, Image, styled, Avatar, Text, View, ScrollView } from 'tamagui';
+import {
+  Button,
+  YStack,
+  Image,
+  styled,
+  Avatar,
+  Text,
+  View,
+  ScrollView,
+} from 'tamagui';
 
 export default function Index() {
   const backgroundImage = { uri: 'https://picsum.photos/1080/1920' };


### PR DESCRIPTION
This is related to issue #23 

## Description / Changes Made

- Implemented the background image with the Tamagui Image component to maintain coding consistency
   - Change was not made exactly as suggested in the issue. 
   - Tamagui Image does not take any children, so the background image is an absolute position Image nested in a View
- Added scroll view
   - The scroll view helps to ensure the background image is working properly
   - The scroll view also will be useful for the future development like in requesting more posts
- Code splitting was not implemented since I would like to have a frontend meeting discussing it first 


## How to Test

1. Navigate to Home
2. Gesture to scroll up
3. There are no other posts, so you should see the image move up along with the righthand components while whitespace appears at the bottom
4. Open `frontend/app/(tabs)/index.tsx` to see that BackgroundImage from react-native is no longer used nor imported

## Checklist

- [x] I have added/updated relevant documentation, and I have followed the coding style guidelines.
- [x] I have checked for any potential conflicts with other branches and fixed any merge conflicts.
