### PR TITLE
Fixing Token Decoding Issue #61

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -54,7 +54,7 @@ def middleware():
     print("\nIncoming request:", request.method, request.path)
 
     # Check for Authorization header containing JWT token
-    token = request.headers.get("Authorization")
+    token = request.headers.get("Authorization").split(" ")[1]
     if token:
         try:
             # Verify and decode JWT token
@@ -65,7 +65,7 @@ def middleware():
             )
 
             # Extract user_id and API details from the request
-            user_id = decoded_token["uid"]
+            user_id = decoded_token["sub"]
 
             # Extract API name and address from request path
             api_name = request.path.split("/", 2)[-1].split("/", 1)[0]


### PR DESCRIPTION
Closes #61 

## Description / Changes Made

- _The JWT tokens now created and passed from the frontend have a "Bearer" prefix and use the field "sub" instead of "uid"._
- _I modified line 57 to split the string on spaces and take only the 1st index value as this is the actual token we want._
- _I modified line 68 to retrieve the "sub" field of the decoded token as the "uid" field is now invalid with the way JWT tokens are passed._

## How to Test

1. _Add following code into `frontend/app/(tabs)/index.tsx` at the top of the export function `Index()`:_
```
const { getToken } = useAuth();

  useEffect(() => {
    (async () => {
      const token = await getToken();
      console.log(token);
    })();
  }, []);
```
_You must also add the respective imports for the above code:_
```
import { useAuth } from '@clerk/clerk-expo';
import { useEffect } from 'react';
```
2. _Start the front end, and after logging in through the profile page, you will see the JWT token logged to the console._
3. _Add the prefix "Bearer " to the newly created JWT token in the Authentication header in Postman, and test any routes._
4. (Optional) _You can put the newly created JWT token in to https://jwt.io to verify the JWT token has a "sub" field instead of a "uid" field._

## Checklist

- [ x ] I have added/updated relevant documentation, and I have followed the coding style guidelines.
- [ x ] I have checked for any potential conflicts with other branches and fixed any merge conflicts.
- [ x ] I have verified that a newly created JWT token with the proper "Bearer" prefix in the Authentication header decodes as expected.
