### PR TITLE
Add API Call For User Edits

### DIFF
--- a/frontend/app/(tabs)/profile/index.tsx
+++ b/frontend/app/(tabs)/profile/index.tsx
@@ -79,6 +79,7 @@ export default function Profile() {
           <YStack>
             <Card elevate size={'$3'} bordered unstyled>
               <XStack justifyContent='space-between'>
+                {/* Card header*/}
                 <Card.Header
                   display='flex'
                   flexDirection='row'
@@ -86,30 +87,37 @@ export default function Profile() {
                   justifyContent='space-between'
                   alignItems='center'
                 >
+                  {/* Avatar*/}
                   <TouchableOpacity onPress={handleUserProfileChange}>
                     <Avatar circular size={'$5'}>
                       <Avatar.Image src={user.imageUrl ?? ' '} />
                     </Avatar>
                   </TouchableOpacity>
+                  {/* User Info */}
                   <YStack gap={'$2'}>
+                    {/* User name*/}
                     <H4>{user?.username}</H4>
+                    {/* Name*/}
                     <Paragraph>{`${user?.firstName} ${
                       user?.lastName ?? ''
                     }`}</Paragraph>
+                    {/* Bio */}
                     <Paragraph>{`${user_data.bio}`}</Paragraph>
                   </YStack>
                 </Card.Header>
                 <XStack gap={'$3'}>
+                  {/* Follower count */}
                   <YStack display='flex' alignItems='center'>
                     <Label fontSize={'$2'}>Followers</Label>
                     <Text>{user_data.followers.length ?? 0}</Text>
                   </YStack>
-
+                  {/* Following count*/}
                   <YStack display='flex' alignItems='center'>
                     <Label fontSize={'$2'}>Following</Label>
                     <Text>{user_data.following.length ?? 0}</Text>
                   </YStack>
                 </XStack>
+                {/* Edit button */}
                 <Link href='/profile/profileEditModal' asChild>
                   <Button
                     iconAfter={<Feather name={'edit'} size={20} />}

--- a/frontend/app/(tabs)/profile/profileEditModal.tsx
+++ b/frontend/app/(tabs)/profile/profileEditModal.tsx
@@ -1,11 +1,8 @@
 import UserInput from '@/components/UserInput';
-import { UserContext } from '@/contexts/UserContext';
 import { UserState } from '@/types/user';
 import { isClerkAPIResponseError, useUser } from '@clerk/clerk-expo';
-import axios from 'axios';
 import { MediaTypeOptions, launchImageLibraryAsync } from 'expo-image-picker';
 import { Stack } from 'expo-router';
-import { useContext } from 'react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { TouchableOpacity } from 'react-native';
 import Toast from 'react-native-toast-message';
@@ -25,7 +22,6 @@ const ProfileEditModal = () => {
       password: user?.passwordEnabled ? 'password' : '',
     },
   });
-  const { token, user_data, user_id:userId } = useContext(UserContext);
 
   const updateUserData: SubmitHandler<UserState> = async (data) => {
     try {
@@ -39,21 +35,11 @@ const ProfileEditModal = () => {
           lastName: data.lastName,
         });
       }
+
       if (isNotDirtyClerk) {
-        // create userData to pass to backend
-        const userData = {
-          ...user_data,
-          bio: data.bio,
-          username: data.username
-        }
-        
-        await axios.patch(`${process.env.EXPO_PUBLIC_IP_ADDR}/api/users/${userId}`,     // API route
-                            userData,                                                   // userData to update
-                            { headers: { Authorization: `Bearer: ${token}` },},         // auth header
-                          )
-                      .then(() => user?.update({username: data.username}))              // update user username
-                      .catch(error => console.log('error:',error.message))              // console log any errors
+        //api call to update
       }
+
       if (isDirty) {
         Toast.show({ text1: 'Profile Updated', type: 'success' });
       }
@@ -158,7 +144,7 @@ const ProfileEditModal = () => {
                   field={field}
                   useLabel
                   labelID='Bio'
-                  placeholder={user_data.bio}
+                  placeholder={user?.bio ?? 'Bio'}
                 />
               </XStack>
             )}

--- a/frontend/app/(tabs)/profile/profileEditModal.tsx
+++ b/frontend/app/(tabs)/profile/profileEditModal.tsx
@@ -25,7 +25,7 @@ const ProfileEditModal = () => {
       password: user?.passwordEnabled ? 'password' : '',
     },
   });
-  const { token, user_data, user_id:userId } = useContext(UserContext);
+  const { token, user_data, user_id: userId } = useContext(UserContext);
 
   const updateUserData: SubmitHandler<UserState> = async (data) => {
     try {
@@ -44,15 +44,17 @@ const ProfileEditModal = () => {
         const userData = {
           ...user_data,
           bio: data.bio,
-          username: data.username
-        }
-        
-        await axios.patch(`${process.env.EXPO_PUBLIC_IP_ADDR}/api/users/${userId}`,     // API route
-                            userData,                                                   // userData to update
-                            { headers: { Authorization: `Bearer: ${token}` },},         // auth header
-                          )
-                      .then(() => user?.update({username: data.username}))              // update user username
-                      .catch(error => console.log('error:',error.message))              // console log any errors
+          username: data.username,
+        };
+
+        await axios
+          .patch(
+            `${process.env.EXPO_PUBLIC_IP_ADDR}/api/users/${userId}`, // API route
+            userData, // userData to update
+            { headers: { Authorization: `Bearer: ${token}` } }, // auth header
+          )
+          .then(() => user?.update({ username: data.username })) // update user username
+          .catch((error) => console.log('error:', error.message)); // console log any errors
       }
       if (isDirty) {
         Toast.show({ text1: 'Profile Updated', type: 'success' });


### PR DESCRIPTION
## Description / Changes Made
- Added an API Call to send changes to a user's username and bio to the backend
- Added some comments into profile's index.tsx

## Portions of this code that utilized AI generation
None used. Was able to code everything based on previous work and documentation.

## Screenshots (optional)

![image](#)

## How to Test
1. Start up Firebase emulator, server.py, and the front end
2. Log into a user
3. Navigate to Profile
4. Press the edit button in the corner
5. Edit your username and/or your bio
6. Press the button
7. The components should reload. When you go back to the profile page, you should see the changes reflected
8. If you look at the Firebase emulator, you should see your edits also there

## Checklist

- [x] I have added/updated relevant documentation, and I have followed the coding style guidelines.
- [ ] I have checked for any potential conflicts with other branches and fixed any merge conflicts.
